### PR TITLE
Fix regex error when fetch nonexistent file w/ adb

### DIFF
--- a/andriller/adb_conn.py
+++ b/andriller/adb_conn.py
@@ -133,6 +133,8 @@ class ADBConn:
     def exists(self, file_path, **kwargs):
         file_path_strict = self.strict_name(file_path)
         file_remote = self.adb(f'shell ls {file_path_strict}', **kwargs)
+        if not file_remote:
+            return None
         if re.match(self._file_regex(file_path), file_remote):
             return file_remote
 


### PR DESCRIPTION
`file_remote` will be `None` if file to be checked does not exist on the device, which will result in a Python regex exception.