### PR TITLE
Extract call logs from a separate database

### DIFF
--- a/andriller/decoders.py
+++ b/andriller/decoders.py
@@ -291,6 +291,7 @@ class SamsungCallsDecoder(GenericCallsDecoder):
             i['duration'] = self.duration(i['duration'])
             self.DATA.append(i)
 
+
 # -----------------------------------------------------------------------------
 class AndroidOneCallsDecoder(GenericCallsDecoder):
     TARGET = 'calllog.db'
@@ -309,6 +310,7 @@ class AndroidOneCallsDecoder(GenericCallsDecoder):
             i['date'] = self.unix_to_time_ms(i['date'])
             i['duration'] = self.duration(i['duration'])
             self.DATA.append(i)
+
 
 # -----------------------------------------------------------------------------
 class SamsungSnippetsDecoder(AndroidDecoder):

--- a/andriller/decoders.py
+++ b/andriller/decoders.py
@@ -291,6 +291,24 @@ class SamsungCallsDecoder(GenericCallsDecoder):
             i['duration'] = self.duration(i['duration'])
             self.DATA.append(i)
 
+# -----------------------------------------------------------------------------
+class AndroidOneCallsDecoder(GenericCallsDecoder):
+    TARGET = 'calllog.db'
+    NAMESPACE = 'db'
+    PACKAGE = 'com.android.providers.contacts'
+
+    def __init__(self, work_dir, input_file, **kwargs):
+        super().__init__(work_dir, input_file, **kwargs)
+        self.title = 'Android One Call Logs'
+
+    def main(self):
+        table = 'calls'
+        for i in self.sql_table_as_dict(table, order_by='date'):
+            i['type'] = self.call_type(i['type'])
+            i['number'] = self.parse_number(i['number'])
+            i['date'] = self.unix_to_time_ms(i['date'])
+            i['duration'] = self.duration(i['duration'])
+            self.DATA.append(i)
 
 # -----------------------------------------------------------------------------
 class SamsungSnippetsDecoder(AndroidDecoder):


### PR DESCRIPTION
Extract call logs from `/data/data/com.android.providers.contacts/databases/calllog.db` if it exists. Fixes #14 

TODO: This should probably catch the error thrown by `GenericCallsDecoder` when the call log is in its own database and missing from `contacts2.db`.